### PR TITLE
Util: Add a retry method to handle intermittent errors

### DIFF
--- a/lib/repo/fetch.js
+++ b/lib/repo/fetch.js
@@ -1,7 +1,8 @@
 var Promise = require( "es6-promise" ).Promise,
 	fs = require( "fs" ),
 	exec = require( "child_process" ).exec,
-	mkdirp = require( "mkdirp" );
+	mkdirp = require( "mkdirp" ),
+	util = require( "../util" );
 
 module.exports = function( Repo ) {
 
@@ -26,7 +27,9 @@ Repo.prototype.fetch = function( ref ) {
 
 	return repo.hasCloned
 		.then(function() {
-			return repo._fetch( ref );
+			return util.retry(function() {
+				return repo._fetch( ref );
+			});
 		});
 };
 
@@ -93,17 +96,17 @@ Repo.prototype._clone = function() {
 Repo.prototype._fetch = function( ref ) {
 	var repo = this;
 
-	repo.debug( "fetching repo" );
+	repo.debug( "fetching " + ref );
 	return new Promise(function( resolve, reject ) {
 		exec( "git fetch -fu origin refs/" + ref + ":" + ref, {
 			cwd: repo.path
 		}, function( error ) {
 			if ( error ) {
-				repo.debug( "error fetching repo", error );
+				repo.debug( "error fetching " + ref, error );
 				return reject( error );
 			}
 
-			repo.debug( "successfully fetched repo" );
+			repo.debug( "successfully fetched " + ref );
 			resolve();
 		});
 	});

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,31 @@
+var Promise = require( "es6-promise" ).Promise;
+
+var util = module.exports = {};
+
+util.delay = function( method, duration ) {
+	return new Promise(function( resolve, reject ) {
+		setTimeout(function() {
+			method()
+				.then( resolve )
+				.catch( reject );
+		}, duration );
+	});
+};
+
+util.retry = function( method, attempts ) {
+	attempts = attempts || 0;
+
+	return method()
+		.catch(function( error ) {
+			attempts++;
+
+			// After three failures, just return the error
+			if ( attempts === 3 ) {
+				throw error;
+			}
+
+			return util.delay(function() {
+				return util.retry( method, attempts );
+			}, Math.pow( 2, attempts ) * 1000 );
+		});
+};

--- a/test/repo.js
+++ b/test/repo.js
@@ -1,7 +1,8 @@
 var fs = require( "fs" ),
 	Promise = require( "es6-promise" ).Promise,
 	config = require( "../lib/config" ),
-	Repo = require ( "../lib/repo" );
+	Repo = require ( "../lib/repo" ),
+	util = require( "../lib/util" );
 
 exports.get = {
 	"returns singleton": function( test ) {
@@ -21,6 +22,18 @@ exports.get = {
 exports.fetch = {
 	setUp: function( done ) {
 		this.repo = new Repo( "test-repo" );
+
+		this.retry = util.retry;
+		util.retry = function( method ) {
+			return method();
+		};
+
+		done();
+	},
+
+	tearDown: function( done ) {
+		util.retry = this.retry;
+
 		done();
 	},
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,123 @@
+var Promise = require( "es6-promise" ).Promise,
+	util = require ( "../lib/util" );
+
+exports.retry = {
+	setUp: function( done ) {
+		this.delay = util.delay;
+		done();
+	},
+
+	tearDown: function( done ) {
+		util.delay = this.delay;
+		done();
+	},
+
+	"success on first attempt": function( test ) {
+		test.expect( 2 );
+
+		var promise,
+			providedValue = {};
+
+		promise = util.retry(function() {
+			test.ok( true, "Method should be invoked once" );
+			return Promise.resolve( providedValue );
+		});
+
+		promise.then(function( value ) {
+			test.strictEqual( value, providedValue, "Should pass along value" );
+			test.done();
+		});
+	},
+
+	"success on second attempt": function( test ) {
+		test.expect( 4 );
+
+		var promise, method,
+			realDelay = this.delay,
+			providedValue = {};
+
+		function method1() {
+			test.ok( true, "Method should be invoked once" );
+
+			method = method2;
+			util.delay = function( method, duration ) {
+				test.equal( duration, 2000, "Should delay for 2 seconds" );
+				return realDelay( method, 1 );
+			};
+
+			return Promise.reject( new Error() );
+		}
+
+		function method2() {
+			test.ok( true, "Method should be invoked twice" );
+
+			util.delay = function() {
+				test.ok( false, "Should not delay after resolving" );
+			};
+
+			return Promise.resolve( providedValue );
+		}
+
+		method = method1;
+		promise = util.retry(function() {
+			return method();
+		});
+
+		promise.then(function( value ) {
+			test.strictEqual( value, providedValue, "Should pass along value" );
+			test.done();
+		});
+	},
+
+	"error on third attempt": function( test ) {
+		test.expect( 6 );
+
+		var promise, method,
+			realDelay = this.delay,
+			providedError = new Error();
+
+		function method1() {
+			test.ok( true, "Method should be invoked once" );
+
+			method = method2;
+			util.delay = function( method, duration ) {
+				test.equal( duration, 2000, "Should delay for 2 seconds" );
+				return realDelay( method, 1 );
+			};
+
+			return Promise.reject( new Error() );
+		}
+
+		function method2() {
+			test.ok( true, "Method should be invoked twice" );
+
+			method = method3;
+			util.delay = function( method, duration ) {
+				test.equal( duration, 4000, "Should delay for 4 seconds" );
+				return realDelay( method, 1 );
+			};
+
+			return Promise.reject( new Error() );
+		}
+
+		function method3() {
+			test.ok( true, "Method should be invoked thrice" );
+
+			util.delay = function() {
+				test.ok( false, "Should not delay after three failures" );
+			};
+
+			return Promise.reject( providedError );
+		}
+
+		method = method1;
+		promise = util.retry(function() {
+			return method();
+		});
+
+		promise.catch(function( error ) {
+			test.strictEqual( error, providedError, "Should pass along error" );
+			test.done();
+		});
+	}
+};


### PR DESCRIPTION
`util.retry()` will invoke a promise-returning method and if the promise is
rejected, it will try again in 2 seconds. If that promise is rejected, it will
try again in 4 seconds. If that promise is rejected, the error will propagate.

This should hopefully fix the error where the PR branch doesn't exist by the
time we process the webhook.

Fixes gh-23