### PR TITLE
Server: Recheck failed events when new signatures are found

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -76,6 +76,10 @@ function prHook( event, done ) {
 				state: "error",
 				description: "There was an error checking the CLA status"
 			})
+				.then(function() {
+					failedEvents.push( event );
+					done();
+				})
 				.catch(function( error ) {
 					logger.error( "Error setting status", {
 						repo: event.repo,
@@ -83,10 +87,9 @@ function prHook( event, done ) {
 						head: event.head,
 						error: error.stack
 					});
+					failedEvents.push( event );
 					done();
 				});
-			failedEvents.push( event );
-			done();
 		}
 	);
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "test": "nodeunit"
   },
   "bin": {
-    "jquery-audit-branch": "./bin/audit.js",
+    "jquery-audit-branch": "./bin/audit-branch.js",
     "jquery-audit-pr": "./bin/audit-pr.js"
   },
   "dependencies": {
+    "async": "1.4.0",
     "debug": "2.1.1",
     "es6-promise": "2.0.1",
     "git-notifier": "2.1.0",
@@ -34,6 +35,7 @@
     "unorm": "1.3.3"
   },
   "devDependencies": {
-    "nodeunit": "0.9.0"
+    "nodeunit": "0.9.0",
+    "sinon": "1.15.4"
   }
 }

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,87 @@
+var sinon = require( "sinon" ),
+	http = require( "http" ),
+	gitNotifier = require( "git-notifier" ),
+	Repo = require( "../lib/repo" ),
+	pr = require( "../lib/pr" ),
+	signatures = require( "../lib/signatures" ),
+	config = require( "../lib/config" );
+
+exports.get = {
+	setUp: function( done ) {
+		this.setTimeout = setTimeout;
+		this.clock = sinon.useFakeTimers();
+		this.sandbox = sinon.sandbox.create();
+		this.sandbox.stub( http, "createServer" ).returns( {
+			on: function() {},
+			listen: function() {}
+		} );
+		this.sandbox.stub( gitNotifier, "Notifier" ).returns( {
+			on: function( event, callback ) {
+				if ( event === "error" ) {
+					return;
+				}
+				this.notifierEvent = event;
+				this.notifierCallback = callback;
+			}.bind( this )
+		} );
+		this.sandbox.stub( Repo, "get" ).returns( {
+			setStatus: function() {}
+		} );
+		this.sandbox.stub( pr, "audit" ).returns( Promise.resolve( {
+			state: "failure"
+		} ) );
+		this.sandbox.stub( signatures, "hashed" ).returns( Promise.resolve( {
+			"name@email.com": "Firstname Lastname"
+		} ) );
+		config.owner = "testuser";
+		config.port = 8888;
+		config.signatureRefresh = 0;
+		done();
+	},
+	tearDown: function( done ) {
+		this.clock.restore();
+		this.sandbox.restore();
+		done();
+	},
+	"basics": function( test ) {
+		test.expect( 4 );
+
+		require( "../bin/server.js" );
+
+		var payload = {
+			action: "synchronize",
+			pull_request: {
+				base: {},
+				head: {}
+			}
+		};
+		this.notifierCallback( {
+			repo: "testrepo",
+			pr: "testpr",
+			payload: payload
+		} );
+		this.notifierCallback( {
+			repo: "testrepo2",
+			pr: "testpr2",
+			payload: payload
+		} );
+		test.equal( signatures.hashed.callCount, 1 );
+
+		this.setTimeout( function() {
+			test.equal( pr.audit.callCount, 2 );
+
+			signatures.hashed.returns( Promise.resolve( {
+				"name@email.com": "Firstname Lastname",
+				"new@email.com": "New Name"
+			} ) );
+
+			this.clock.tick( 1 );
+			this.setTimeout( function() {
+				test.equal( signatures.hashed.callCount, 2 );
+				test.equal( pr.audit.callCount, 4 );
+
+				test.done();
+			}, 100 );
+		}.bind( this ) );
+	}
+};

--- a/test/server.js
+++ b/test/server.js
@@ -20,7 +20,6 @@ exports.get = {
 				if ( event === "error" ) {
 					return;
 				}
-				this.notifierEvent = event;
 				this.notifierCallback = callback;
 			}.bind( this )
 		} );
@@ -67,6 +66,7 @@ exports.get = {
 		} );
 		test.equal( signatures.hashed.callCount, 1 );
 
+		// Promise.resolve is async, wait for signatures to resolve
 		this.setTimeout( function() {
 			test.equal( pr.audit.callCount, 2 );
 
@@ -75,13 +75,16 @@ exports.get = {
 				"new@email.com": "New Name"
 			} ) );
 
+			// Trigger signature refresh timeout
 			this.clock.tick( 1 );
+
+			// Same waiting as above
 			this.setTimeout( function() {
 				test.equal( signatures.hashed.callCount, 2 );
 				test.equal( pr.audit.callCount, 4 );
 
 				test.done();
-			}, 100 );
+			} );
 		}.bind( this ) );
 	}
 };


### PR DESCRIPTION
Fixes #6

I've tested this with [a standalone repo on my own account](https://github.com/jzaefferer/cla-test/pull/1), [a script that starts the server with mocked signatures which change over time](https://gist.github.com/jzaefferer/c02648d2f444cdf3e9cb) and another [script that emulates the webhook with a payload taken from the hooks page](https://gist.github.com/jzaefferer/bfa7887700d61821f7f5). With this I can start the server, have it check the CLA and mark it as invalid, then after a few seconds it finds a new signature, automatically checks the previously failed PR again and ends up marking it as valid.

Would like to get some feedback to this implementation. If it seems sound, I'll write tests that cover the same code as the manual test I'm currently doing. Once those are in place, we can refactor the server code.