### PR TITLE
Signatures: Make module testable, add test for hashed method

### DIFF
--- a/lib/signatures.js
+++ b/lib/signatures.js
@@ -44,7 +44,7 @@ function getRawSignatures( key ) {
 }
 
 function getSignatures( key ) {
-	return getRawSignatures( key ).then(function( data ) {
+	return module.exports.raw( key ).then(function( data ) {
 		return validate( data ).authors;
 	});
 }
@@ -154,5 +154,8 @@ module.exports = {
 	caa: caa,
 	all: all,
 	hashed: hashed,
+
+	// Only for tests
+	raw: getRawSignatures,
 	errors: getSignatureErrors
 };

--- a/test/signatures-caa.json
+++ b/test/signatures-caa.json
@@ -1,0 +1,125 @@
+[
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/1"
+		},
+		"updated": {
+			"$t": "2015-03-18T17:22:33.363Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/11/2013 13:55:53"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Scott González, emailaddress: scott.gonzalez@gmail.com, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/1"
+			}
+		],
+		"gsx$timestamp": {
+			"$t": "7/11/2013 13:55:53"
+		},
+		"gsx$fullname": {
+			"$t": "Scott González"
+		},
+		"gsx$emailaddress": {
+			"$t": "scott.gonzalez@gmail.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		}
+	},
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/2"
+		},
+		"updated": {
+			"$t": "2015-03-18T17:22:33.363Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/11/2013 15:36:17"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Alexander Schmitz, emailaddress: arschmitz@gmail.com, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/2"
+			}
+		],
+		"gsx$timestamp": {
+			"$t": "7/11/2013 15:36:17"
+		},
+		"gsx$fullname": {
+			"$t": "Alexander Schmitz"
+		},
+		"gsx$emailaddress": {
+			"$t": "arschmitz@gmail.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		}
+	},
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/3"
+		},
+		"updated": {
+			"$t": "2015-03-19T17:22:33.363Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/11/2013 15:36:17"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Jörn Zaefferer, emailaddress: joern.zaefferer@gmail.com, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/3"
+			}
+		],
+		"gsx$timestamp": {
+			"$t": "8/11/2013 15:36:17"
+		},
+		"gsx$fullname": {
+			"$t": "Jörn Zaefferer"
+		},
+		"gsx$emailaddress": {
+			"$t": "joern.zaefferer@gmail.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		}
+	}
+]

--- a/test/signatures-cla.json
+++ b/test/signatures-cla.json
@@ -1,0 +1,222 @@
+[
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/1"
+		},
+		"updated": {
+			"$t": "2015-07-30T08:35:43.323Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "11/12/2014 15:21:35"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Peter Pan, emailaddress: github@pan.com, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/1"
+			}
+		],
+		"gsx$_cn6ca": {
+			"$t": "11/12/2014 15:21:35"
+		},
+		"gsx$fullname": {
+			"$t": "Peter Pan"
+		},
+		"gsx$emailaddress": {
+			"$t": "github@pan.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/2"
+		},
+		"updated": {
+			"$t": "2015-07-30T08:35:43.323Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/29/2015 16:53:13"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Peter Pan, emailaddress: code@pan.com, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/2"
+			}
+		],
+		"gsx$_cn6ca": {
+			"$t": "7/29/2015 16:53:13"
+		},
+		"gsx$fullname": {
+			"$t": "Peter Pan"
+		},
+		"gsx$emailaddress": {
+			"$t": "code@pan.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/3"
+		},
+		"updated": {
+			"$t": "2015-07-30T08:35:43.323Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/29/2015 23:24:33"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Alice Wonderland, emailaddress: alice@wonderland.eu, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/3"
+			}
+		],
+		"gsx$_cn6ca": {
+			"$t": "7/29/2015 23:24:33"
+		},
+		"gsx$fullname": {
+			"$t": "Alice Wonderland"
+		},
+		"gsx$emailaddress": {
+			"$t": "alice@wonderland.eu"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/4"
+		},
+		"updated": {
+			"$t": "2015-07-30T08:35:43.323Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/29/2015 23:24:52"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Alice Wonderland, emailaddress: alice@wonderland.eu, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/4"
+			}
+		],
+		"gsx$_cn6ca": {
+			"$t": "7/29/2015 23:24:52"
+		},
+		"gsx$fullname": {
+			"$t": "Alice Wonderland"
+		},
+		"gsx$emailaddress": {
+			"$t": "alice@wonderland.eu"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"id": {
+			"$t": "https://spreadsheets.google.com/feeds/list/xyz123/1/public/values/5"
+		},
+		"updated": {
+			"$t": "2015-07-30T08:35:43.323Z"
+		},
+		"category": [
+			{
+				"scheme": "http://schemas.google.com/spreadsheets/2006",
+				"term": "http://schemas.google.com/spreadsheets/2006#list"
+			}
+		],
+		"title": {
+			"type": "text",
+			"$t": "7/30/2015 4:35:43"
+		},
+		"content": {
+			"type": "text",
+			"$t": "fullname: Bob Belcher, emailaddress: bobbelcher@gmail.com, confirmation: I AGREE"
+		},
+		"link": [
+			{
+				"rel": "self",
+				"type": "application/atom+xml",
+				"href": "http://spreadsheets.google.com/feeds/list/xyz123/1/public/values/5"
+			}
+		],
+		"gsx$_cn6ca": {
+			"$t": "7/30/2015 4:35:43"
+		},
+		"gsx$fullname": {
+			"$t": "Bob Belcher"
+		},
+		"gsx$emailaddress": {
+			"$t": "bobbelcher@gmail.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	}
+]

--- a/test/signatures.js
+++ b/test/signatures.js
@@ -1,0 +1,40 @@
+var sinon = require( "sinon" );
+var signatures = require( "../lib/signatures" );
+var caaSignatures = require( "./signatures-caa.json" );
+var claSignatures = require( "./signatures-cla.json" );
+
+exports.hashed = {
+	setUp: function( done ) {
+		this.sandbox = sinon.sandbox.create();
+		this.sandbox.stub( signatures, "raw" );
+		signatures.raw.onCall( 0 ).returns( Promise.resolve( claSignatures ) );
+		signatures.raw.onCall( 1 ).returns( Promise.resolve( caaSignatures ) );
+		done();
+	},
+	tearDown: function( done ) {
+		this.sandbox.restore();
+		done();
+	},
+	basics: function( test ) {
+		test.expect( 1 );
+
+		signatures.hashed()
+			.then( function( result ) {
+				test.deepEqual( result, {
+					"github@pan.com": "Peter Pan",
+					"code@pan.com": "Peter Pan",
+					"alice@wonderland.eu": "Alice Wonderland",
+					"bobbelcher@gmail.com": "Bob Belcher",
+					"scott.gonzalez@gmail.com": "Scott González",
+					"arschmitz@gmail.com": "Alexander Schmitz",
+					"joern.zaefferer@gmail.com": "Jörn Zaefferer"
+				} );
+				test.done();
+			} )
+			.catch( function( error ) {
+				console.log( error, error.stack );
+				test.ok( false, error );
+				test.done();
+			} );
+	}
+};


### PR DESCRIPTION
In preparation for upcoming changes to the signatures module.

Ref #32

I'm not too happy with this approach, but I find it still much better over mocking `http.request`.