### PR TITLE
Signatures: Address a valid signature that has an invalid duplicate

### DIFF
--- a/lib/signatures.js
+++ b/lib/signatures.js
@@ -92,8 +92,23 @@ function validate( entries ) {
 		var duplicates = result.slice( 0, index ).filter( function( x ) {
 			return x.email === entry.email;
 		} );
+
+		// If this valid entry has an invalid duplicate, replace the duplicate
+		if ( duplicates.length && !entry.errors.length && duplicates[ 0 ].errors.length ) {
+			duplicates[ 0 ].names = entry.names;
+			duplicates[ 0 ].errors = [];
+			return false;
+		}
+
+		// If this invalid entry has a valid duplicate, drop it
+		if ( duplicates.length && entry.errors.length && !duplicates[ 0 ].errors.length ) {
+			return false;
+		}
+
 		if ( duplicates.length ) {
 			duplicates[ 0 ].names = unique( duplicates[ 0 ].names.concat( entry.names ) ).reverse();
+			duplicates[ 0 ].errors = unique( duplicates[ 0 ].errors.concat( entry.errors ) )
+				.reverse();
 			return false;
 		}
 		return true;

--- a/test/signatures-cla.json
+++ b/test/signatures-cla.json
@@ -99,10 +99,10 @@
 	},
 	{
 		"gsx$fullname": {
-			"$t": "Jaron Noraj"
+			"$t": "No Agree"
 		},
 		"gsx$emailaddress": {
-			"$t": "jaronnoraj@gmail.com"
+			"$t": "noagree@gmail.com"
 		},
 		"gsx$confirmation": {
 			"$t": "I DON'T AGREE"
@@ -113,10 +113,10 @@
 	},
 	{
 		"gsx$fullname": {
-			"$t": "Jaron Noraj"
+			"$t": "Invalid Email"
 		},
 		"gsx$emailaddress": {
-			"$t": "jaronnorajgmail.com"
+			"$t": "invalidemail.com"
 		},
 		"gsx$confirmation": {
 			"$t": "I AGREE"
@@ -127,10 +127,10 @@
 	},
 	{
 		"gsx$fullname": {
-			"$t": "Jaron Noraj"
+			"$t": "Invalid Host"
 		},
 		"gsx$emailaddress": {
-			"$t": "jaron@noreply.github.com"
+			"$t": "invalidhost@noreply.github.com"
 		},
 		"gsx$confirmation": {
 			"$t": "I AGREE"
@@ -141,10 +141,66 @@
 	},
 	{
 		"gsx$fullname": {
-			"$t": "JaronNoraj"
+			"$t": "InvalidName"
 		},
 		"gsx$emailaddress": {
-			"$t": "jaronnoraj@email.com"
+			"$t": "invalidname@email.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"gsx$fullname": {
+			"$t": "Double Signature"
+		},
+		"gsx$emailaddress": {
+			"$t": "doublesignature@email.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"gsx$fullname": {
+			"$t": "DoubleSignature"
+		},
+		"gsx$emailaddress": {
+			"$t": "doublesignature@email.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"gsx$fullname": {
+			"$t": "ReverseDouble"
+		},
+		"gsx$emailaddress": {
+			"$t": "reversedouble@email.com"
+		},
+		"gsx$confirmation": {
+			"$t": "I AGREE"
+		},
+		"gsx$nameconfirmation": {
+			"$t": ""
+		}
+	},
+	{
+		"gsx$fullname": {
+			"$t": "Reverse Double"
+		},
+		"gsx$emailaddress": {
+			"$t": "reversedouble@email.com"
 		},
 		"gsx$confirmation": {
 			"$t": "I AGREE"

--- a/test/signatures.js
+++ b/test/signatures.js
@@ -33,22 +33,25 @@ exports.hashed = {
 						errors: []
 					},
 					"bobbelcher@gmail.com": { names: [ "Bob Belcher" ], errors: [] },
-					"jaronnoraj@gmail.com": {
-						names: [ "Jaron Noraj" ],
-						errors: [ "jaronnoraj@gmail.com did not properly confirm agreement." ]
+					"noagree@gmail.com": {
+						names: [ "No Agree" ],
+						errors: [ "noagree@gmail.com did not properly confirm agreement." ]
 					},
-					"jaronnorajgmail.com": {
-						names: [ "Jaron Noraj" ],
-						errors: [ "jaronnorajgmail.com is not a valid email address." ]
+					"invalidemail.com": {
+						names: [ "Invalid Email" ],
+						errors: [ "invalidemail.com is not a valid email address." ]
 					},
-					"jaron@noreply.github.com": {
-						names: [ "Jaron Noraj" ],
-						errors: [ "jaron@noreply.github.com is a private GitHub email address." ]
+					"invalidhost@noreply.github.com": {
+						names: [ "Invalid Host" ],
+						errors: [ "invalidhost@noreply.github.com is a private GitHub email" +
+							" address." ]
 					},
-					"jaronnoraj@email.com": {
-						names: [ "JaronNoraj" ],
-						errors: [ "Suspicious name: JaronNoraj" ]
+					"invalidname@email.com": {
+						names: [ "InvalidName" ],
+						errors: [ "Suspicious name: InvalidName" ]
 					},
+					"doublesignature@email.com": { names: [ "Double Signature" ], errors: [] },
+					"reversedouble@email.com": { names: [ "Reverse Double" ], errors: [] },
 					"scott.gonzalez@gmail.com": { names: [ "Scott González" ], errors: [] },
 					"arschmitz@gmail.com": { names: [ "Alexander Schmitz" ], errors: [] },
 					"joern.zaefferer@gmail.com": { names: [ "Jörn Zaefferer" ], errors: [] }


### PR DESCRIPTION
This only happens when someone signs twice, where the second signature is invalid. The workaround is a bit crude, but should be good enough.

Along with adding fixtures for this specific case, it also updates existing fixtures to make it much more obvious what they're testing.

Fixes #41