### PR TITLE
Audit: Notify user about missing signature with issue comment

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -37,6 +37,7 @@ function prHook( event, done ) {
 	getSignatures().then(
 		function( signatures ) {
 			auditPr( {
+				action: event.payload.action,
 				repo: event.repo,
 				pr: event.pr,
 				baseRemote: event.payload.pull_request.base.git_url,
@@ -113,7 +114,12 @@ getSignatures = ( function() {
 				promise = updatedPromise;
 				if ( Object.keys( signatures ).length !== Object.keys( newSignatures ).length ) {
 					signatures = newSignatures;
-					async.eachSeries( failedEvents.splice( 0 ), prHook );
+					async.eachSeries( failedEvents.splice( 0 ), function( event, done ) {
+
+						// Overide action to avoid posting comments twice
+						event.payload.action = "synchronize";
+						prHook( event, done );
+					} );
 				}
 			} )
 			.catch( function( error ) {

--- a/lib/comment.hbs
+++ b/lib/comment.hbs
@@ -1,0 +1,9 @@
+Thank you for your pull request. It looks like this may be your first contribution to a jQuery Foundation project, if so we need you to sign our Contributor License Agreement (CLA).
+
+__:memo: Please visit http://contribute.jquery.org/CLA/ to sign.__
+
+After you signed, the PR is checked again automatically after a minute. If there's still an issue, please reply here to let us know.
+
+---
+
+If you've already signed our CLA, it's possible your git author information doesn't match your CLA signature (both your name and email have to match), for more information, [check the status of your CLA check](http://contribute.jquery.org/CLA/status/?repo={{repo}}&sha={{head}}).

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -1,10 +1,12 @@
-var fs = require( "fs" ),
-	querystring = require( "querystring" ),
-	Promise = require( "es6-promise" ).Promise,
-	mkdirp = require( "mkdirp" ),
-	createDebugger = require( "debug" ),
-	config = require( "./config" ),
-	Repo = require( "./repo" );
+var fs = require( "fs" );
+var querystring = require( "querystring" );
+var Promise = require( "es6-promise" ).Promise;
+var mkdirp = require( "mkdirp" );
+var createDebugger = require( "debug" );
+var config = require( "./config" );
+var Repo = require( "./repo" );
+var handlebars = require( "handlebars" );
+var commentTemplate = handlebars.compile( fs.readFileSync( __dirname + "/comment.hbs", "utf-8" ) );
 
 function Audit( options ) {
 	if ( !options.repo ) {
@@ -196,6 +198,19 @@ Audit.prototype.logResult = function( result ) {
 	} );
 };
 
+Audit.prototype.postComment = function() {
+
+	// Only post comment on new PRs
+	if ( this.options.action !== "opened" ) {
+		return;
+	}
+
+	return this.repo.addComment( {
+		pr: this.options.pr,
+		body: commentTemplate( this.options )
+	} );
+};
+
 Audit.prototype.finishAudit = function( values ) {
 	var result = values[ 0 ],
 		labels = values[ 1 ],
@@ -212,7 +227,8 @@ Audit.prototype.finishAudit = function( values ) {
 	return Promise.all( [
 		this.logResult( result ),
 		this.repo.setStatus( status ),
-		this.applyLabels( labels, result.state )
+		this.applyLabels( labels, result.state ),
+		this.postComment()
 	] )
 		.then( function() {
 

--- a/lib/repo/github.js
+++ b/lib/repo/github.js
@@ -108,4 +108,13 @@ Repo.prototype.removeLabel = function( options ) {
 	} );
 };
 
+Repo.prototype.addComment = function( options ) {
+	return this.request( {
+		path: "/issues/" + ( options.issue || options.pr ) + "/comments",
+		method: "POST"
+	}, {
+		body: options.body
+	} );
+};
+
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "es6-promise": "2.0.1",
     "git-notifier": "2.1.0",
     "github-request": "1.2.1",
+    "handlebars": "^4.0.1",
     "mkdirp": "0.5.0",
     "mout": "0.11.0",
     "sane-email-validation": "1.0.0",


### PR DESCRIPTION
Fixes #12 

This PR currently uses the nested-linting branch as its base, since the style changes would've caused too many conflicts. Will land them in the right order, so this shouldn't be a problem.

There are no tests for this, as the existing coverage doesn't touch the relevant modules and addressing that causes a lot of overhead. I've tested manually using the PR #45, running a modified `bin/audit-pr.js` that always passes `action: "opened"`, and I've tested the server integration with a script that start the server with mocked signatures which change after a while, and a separate script that sends the correct payload for opening the PR, which also has `action: "opened"`. I don't know how to integrate them into this repo, but if anyone else needs them, [they're in this gist](https://gist.github.com/jzaefferer/aee1933d3f3890dc3651).
