### PR TITLE
Audit: Make email and name checks case-insensitive by lowercasing all

### DIFF
--- a/lib/repo/audit.js
+++ b/lib/repo/audit.js
@@ -41,20 +41,24 @@ Repo.prototype.audit = function( options ) {
 
 		// Filter out authors who have signed a CLA or CAA
 		neglectedCommits = commits.filter( function( commit ) {
-			if ( !signatures.hasOwnProperty( commit.email ) ) {
+			var email = commit.email.toLowerCase();
+			var name = commit.name.toLowerCase();
+			if ( !signatures.hasOwnProperty( email ) ) {
 				return true;
 			}
 
 			// Reject signatures with errors
-			if ( signatures[ commit.email ].errors.length ) {
+			if ( signatures[ email ].errors.length ) {
 				return true;
 			}
 
 			// At least one name must match
-			var noMatchingNames = signatures[ commit.email ].names.indexOf( commit.name ) === -1;
+			var noMatchingNames = signatures[ email ].names.map( function( name ) {
+				return name.toLowerCase();
+			} ).indexOf( name ) === -1;
 			if ( noMatchingNames ) {
-				signatures[ commit.email ].errors.push(
-					"Name on signature (" + signatures[ commit.email ].names.join( ", " ) +
+				signatures[ email ].errors.push(
+					"Name on signature (" + signatures[ email ].names.join( ", " ) +
 					") doesn't match name on commit."
 				);
 			}
@@ -68,18 +72,19 @@ Repo.prototype.audit = function( options ) {
 
 		// Group neglected commits by author
 		neglectedCommits.forEach( function( commit ) {
-			if ( !neglectedAuthors.hasOwnProperty( commit.email ) ) {
-				neglectedAuthors[ commit.email ] = {
+			var email = commit.email.toLowerCase();
+			if ( !neglectedAuthors.hasOwnProperty( email ) ) {
+				neglectedAuthors[ email ] = {
 					name: commit.name,
 					commits: []
 				};
 
-				if ( signatures.hasOwnProperty( commit.email ) ) {
-					neglectedAuthors[ commit.email ].errors = signatures[ commit.email ].errors;
+				if ( signatures.hasOwnProperty( email ) ) {
+					neglectedAuthors[ email ].errors = signatures[ email ].errors;
 				}
 			}
 
-			neglectedAuthors[ commit.email ].commits.push( commit );
+			neglectedAuthors[ email ].commits.push( commit );
 		} );
 
 		// Sort neglected authors by commit count

--- a/lib/signatures.js
+++ b/lib/signatures.js
@@ -82,7 +82,7 @@ function validate( entries ) {
 		// Map to name and email
 		return {
 			names: [ unorm.nfc( row.gsx$fullname.$t ) ],
-			email: row.gsx$emailaddress.$t,
+			email: row.gsx$emailaddress.$t.toLowerCase(),
 			errors: errors
 		};
 	} );

--- a/test/signatures-cla.json
+++ b/test/signatures-cla.json
@@ -4,7 +4,7 @@
 			"$t": "Peter Pan"
 		},
 		"gsx$emailaddress": {
-			"$t": "github@pan.com"
+			"$t": "GitHub@pan.com"
 		},
 		"gsx$confirmation": {
 			"$t": "I AGREE"


### PR DESCRIPTION
Changes the signatures module to return lower cased email and name properties, and updates the audit to lower case commit email and name.

Fixes #47