### PR TITLE
Multiple owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ To manually check a PR, set up a `config.json` with your `githubToken` (next sec
 The Auditing scripts require some configuration. Create a `config.json` in the root of this module with the following properties:
 
 * `owner` (default: `"jquery"`): Which GitHub user/organization to audit.
-  * This only exists for development purposes so that the value can be set to a personal account for testing.
+  When running jquery-license as a webhook server, this property can be specified as an array
+  of strings instead of a single string, to check pull requests against multiple owners/orgs.
 * `repoDir` (default: `"repos"`): Which directory to clone repositories into.
 * `outputDir` (default: `"output"`): Which directory to store PR results into.
   * Results for all PR checks are stored, whether run through the web hook or through the `jquery-audit-pr` binary.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Repo = require( "./lib/repo" ),
 
 module.exports = function( options ) {
 	return getSignatures().then( function( signatures ) {
-		var repo = Repo.get( options.repo );
+		var repo = Repo.get( options.owner, options.repo );
 		return repo.auditBranch( {
 			branch: options.branch || "master",
 			signatures: signatures,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 var path = require( "path" ),
 	debug = require( "debug" )( "config" ),
-	config = require( "../config" ),
+	config,
 	defaults = {
 		owner: "jquery",
 		port: 8000,
@@ -8,6 +8,13 @@ var path = require( "path" ),
 		outputDir: "output",
 		signatureRefresh: 60 * 1000
 	};
+
+try {
+	config = require( "../config" );
+}
+catch ( error ) {
+	config = {};
+}
 
 // Fill in default values for the config
 Object.keys( defaults ).forEach( function( key ) {

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -199,6 +199,7 @@ Audit.prototype.logResult = function( result ) {
 };
 
 Audit.prototype.postComment = function() {
+
 	// Only post comment on new PRs
 	if ( this.options.action !== "opened" ) {
 		return;

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -9,6 +9,9 @@ var handlebars = require( "handlebars" );
 var commentTemplate = handlebars.compile( fs.readFileSync( __dirname + "/comment.hbs", "utf-8" ) );
 
 function Audit( options ) {
+	if ( !options.owner ) {
+		throw new Error( "Missing required option: owner." );
+	}
 	if ( !options.repo ) {
 		throw new Error( "Missing required option: repo." );
 	}
@@ -17,8 +20,8 @@ function Audit( options ) {
 	}
 
 	this.options = options;
-	this.repo = Repo.get( options.repo );
-	this.debug = createDebugger( "audit:" + options.repo + "-" + options.pr );
+	this.repo = Repo.get( options.owner, options.repo );
+	this.debug = createDebugger( "audit:" + options.owner + "/" + options.repo + "-" + options.pr );
 }
 
 Audit.prototype.ensureCommitData = function() {
@@ -164,7 +167,7 @@ Audit.prototype.applyLabels = function( labels, state ) {
 };
 
 Audit.prototype.logResult = function( result ) {
-	var directory = config.outputDir + "/" + this.options.repo + "/" +
+	var directory = config.outputDir + "/" + this.options.owner + "/" + this.options.repo + "/" +
 			this.options.head.substring( 0, 2 ),
 		filename = directory + "/" + this.options.head + ".json",
 		debug = this.debug;
@@ -218,6 +221,7 @@ Audit.prototype.finishAudit = function( values ) {
 			sha: this.options.head,
 			state: result.state,
 			url: "http://contribute.jquery.org/CLA/status/?" + querystring.stringify( {
+				owner: this.options.owner,
 				repo: this.options.repo,
 				sha: this.options.head
 			} ),

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -1,22 +1,32 @@
 var createDebugger = require( "debug" ),
 	config = require( "./config" );
 
-function Repo( name ) {
+function Repo( owner, name ) {
+	this.owner = owner;
 	this.name = name;
 	this.path = config.repoDir + "/" + name;
-	this.remoteUrl = "git://github.com/" + config.owner + "/" + name + ".git";
+	this.remoteUrl = "git://github.com/" + owner + "/" + name + ".git";
 	this.debug = createDebugger( "repo:" + name );
 }
 
 Repo.get = ( function() {
 	var repos = {};
 
-	return function( name ) {
-		if ( !repos.hasOwnProperty( name ) ) {
-			repos[ name ] = new Repo( name );
+	return function( owner, name ) {
+		if ( !owner ) {
+			throw new Error( "Missing required 'owner' argument" );
 		}
 
-		return repos[ name ];
+		if ( !name ) {
+			throw new Error( "Missing required 'name' argument" );
+		}
+
+		var id = owner + "/" + name;
+		if ( !repos.hasOwnProperty( id ) ) {
+			repos[ id ] = new Repo( owner, name );
+		}
+
+		return repos[ id ];
 	};
 } )();
 

--- a/lib/repo/github.js
+++ b/lib/repo/github.js
@@ -15,7 +15,7 @@ module.exports = function( Repo ) {
 
 Repo.prototype.request = function( options, data ) {
 	var requestDebug = requestDebugger();
-	options.path = "/repos/" + config.owner + "/" + this.name + options.path;
+	options.path = "/repos/" + this.owner + "/" + this.name + options.path;
 
 	if ( !options.headers ) {
 		options.headers = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-license",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "License verification for jQuery Foundation projects",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "start": "./bin/server.js",
-    "test": "jshint {.,bin,lib,lib/repo,test}/*.js && jscs {.,bin,lib,lib/repo,test}/*.js && nodeunit"
+    "test": "bash -c 'jshint {.,bin,lib,lib/repo,test}/*.js' && bash -c 'jscs {.,bin,lib,lib/repo,test}/*.js' && nodeunit"
   },
   "bin": {
     "jquery-audit-branch": "./bin/audit-branch.js",
@@ -33,7 +33,7 @@
     "mkdirp": "0.5.0",
     "mout": "0.11.0",
     "sane-email-validation": "1.0.0",
-    "simple-log": "1.2.0",
+    "simple-log": "csnover/simple-log#modern-syslog",
     "unorm": "1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mkdirp": "0.5.0",
     "mout": "0.11.0",
     "sane-email-validation": "1.0.0",
-    "simple-log": "csnover/simple-log#modern-syslog",
+    "simple-log": "1.3.0",
     "unorm": "1.3.3"
   },
   "devDependencies": {

--- a/test/repo.js
+++ b/test/repo.js
@@ -5,14 +5,16 @@ var fs = require( "fs" ),
 
 exports.get = {
 	"returns singleton": function( test ) {
-		test.expect( 3 );
+		test.expect( 5 );
 
-		var instance1 = Repo.get( "test-repo" ),
-			instance2 = Repo.get( "test-repo" ),
-			instance3 = Repo.get( "test-repo-2" );
+		var instance1 = Repo.get( "testuser", "test-repo" ),
+			instance2 = Repo.get( "testuser", "test-repo" ),
+			instance3 = Repo.get( "testuser-2", "test-repo-2" );
 
 		test.equal( instance1.name, "test-repo", "Instance #1 has correct repo name" );
+		test.equal( instance1.owner, "testuser", "Instance #1 has correct owner name" );
 		test.equal( instance3.name, "test-repo-2", "Instance #3 has correct repo name" );
+		test.equal( instance3.owner, "testuser-2", "Instance #3 has correct owner name" );
 		test.strictEqual( instance1, instance2, "Returns same instance per repo" );
 		test.done();
 	}
@@ -20,7 +22,7 @@ exports.get = {
 
 exports.fetch = {
 	setUp: function( done ) {
-		this.repo = new Repo( "test-repo" );
+		this.repo = new Repo( "testuser", "test-repo" );
 		done();
 	},
 
@@ -158,7 +160,7 @@ exports.fetch = {
 
 exports.clone = {
 	setUp: function( done ) {
-		this.repo = new Repo( "test-repo" );
+		this.repo = new Repo( "testuser", "test-repo" );
 		done();
 	},
 
@@ -245,7 +247,7 @@ exports.exists = {
 	setUp: function( done ) {
 		this._stat = fs.stat;
 
-		this.repo = new Repo( "test-repo" );
+		this.repo = new Repo( "testuser", "test-repo" );
 		done();
 	},
 
@@ -312,7 +314,7 @@ exports.exists = {
 
 exports.auditBranch = {
 	setUp: function( done ) {
-		this.repo = new Repo( "my-test" );
+		this.repo = new Repo( "testuser", "my-test" );
 		this.options = {
 			branch: "my-branch",
 			signatures: {},
@@ -397,7 +399,7 @@ exports.auditBranch = {
 
 exports.auditPr = {
 	setUp: function( done ) {
-		this.repo = new Repo( "my-test" );
+		this.repo = new Repo( "testuser", "my-test" );
 		this.options = {
 			pr: 37,
 			baseBranch: "my-base-branch",

--- a/test/signatures.js
+++ b/test/signatures.js
@@ -44,11 +44,13 @@ exports.hashed = {
 					"invalidhost@noreply.github.com": {
 						names: [ "Invalid Host" ],
 						errors: [ "invalidhost@noreply.github.com is a private GitHub email" +
-							" address." ]
+							" address, which we can\'t accept since it can\'t be contacted." +
+							" Please update your commit to another email address, " +
+							" and sign again with that address." ]
 					},
 					"invalidname@email.com": {
 						names: [ "InvalidName" ],
-						errors: [ "Suspicious name: InvalidName" ]
+						errors: [ "The name InvalidName requires manual verification." ]
 					},
 					"doublesignature@email.com": { names: [ "Double Signature" ], errors: [] },
 					"reversedouble@email.com": { names: [ "Reverse Double" ], errors: [] },


### PR DESCRIPTION
This PR allows a single instance to check PRs in multiple orgs. It also fixes existing bugs/test failures. ~~The commit here currently references a local branch for simple-log due to a defect in simple-log, see https://github.com/scottgonzalez/simple-log/pull/5. Once a new version is released I can update the package.json to match, and barring any other feedback this can be landed.~~ This is done.

The minor version number is bumped because there is an incompatible API change with the Repo type, which now accepts an owner & repo, instead of just repo. I didn’t see a lot of reason to try to maintain any backwards-compatibility here.