### PR TITLE
Compare labels in a case insensitive way.

### DIFF
--- a/lib/pr.js
+++ b/lib/pr.js
@@ -90,8 +90,10 @@ Audit.prototype.ensureClaLabels = function() {
 	debug( "ensuring CLA labels exist" );
 
 	function ensureLabel( labels, name, color ) {
+		var lowerName = name.toLowerCase();
+
 		var existingLabel = labels.filter( function( label ) {
-			return label.name === name;
+			return label.name.toLowerCase() === lowerName;
 		} )[ 0 ];
 
 		if ( existingLabel ) {


### PR DESCRIPTION
Compare labels in a case insensitive way since Github labels are case insensitive.
I noticed when I tried to change the labels to lower case that it broke the bot. This PR should avoid that.