### PR TITLE
Remove name check from commit audit

### DIFF
--- a/lib/repo/audit.js
+++ b/lib/repo/audit.js
@@ -54,19 +54,7 @@ Repo.prototype.audit = function( options ) {
 				return true;
 			}
 
-			// At least one name must match
-			var noMatchingNames = signatures[ email ].names.map( function( name ) {
-				return name.toLowerCase();
-			} ).indexOf( name ) === -1;
-
-			if ( noMatchingNames ) {
-				errors.push(
-					"Name on signature (" + signatures[ email ].names.join( ", " ) +
-					") doesn't match name on commit."
-				);
-			}
-
-			return noMatchingNames;
+			return false;
 		} );
 
 		// Filter out exceptions (trivial or removed code)


### PR DESCRIPTION
I have no idea if this works. `npm i` fails on Windows (which I use) due to `modern-syslog` not being supported and there doesn't appear to be a Travis setup to automatically run the tests when I submit a PR. It would be nice to fix both of those. :)

Thus, feedback welcome on if this is correct and what tests should be updated.