### PR TITLE
First pass at renaming jQuery Foundation to JS Foundation.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright jQuery Foundation and other contributors, https://jquery.org/
+Copyright JS Foundation and other contributors, https://js.foundation/
 
 This software consists of voluntary contributions made by many
 individuals. For exact contribution history, see the revision history

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# jQuery Foundation License Verification
+# JS Foundation License Verification
 
-This module audits jQuery Foundation repositories to ensure that all commits have appropriate licensing either via the [CLA](http://contribute.jquery.org/CLA/) or the CAA. This can be run either as a full audit against a given branch of a repository or to verify all commits within a pull request. The latter can be done automatically with a webhook.
+This module audits JS Foundation repositories to ensure that all commits have appropriate licensing either via the [CLA](https://js.foundation/CLA/) or the CAA. This can be run either as a full audit against a given branch of a repository or to verify all commits within a pull request. The latter can be done automatically with a webhook.
 
 To manually check a PR, set up a `config.json` with your `githubToken` (next section), then run the audir-pr script (see PR Auditing below).
 

--- a/lib/comment.hbs
+++ b/lib/comment.hbs
@@ -1,9 +1,9 @@
-Thank you for your pull request. It looks like this may be your first contribution to a jQuery Foundation project, if so we need you to sign our Contributor License Agreement (CLA).
+Thank you for your pull request. It looks like this may be your first contribution to a JS Foundation project, if so we need you to sign our Contributor License Agreement (CLA).
 
-__:memo: Please visit http://contribute.jquery.org/CLA/ to sign.__
+__:memo: Please visit https://js.foundation/CLA/ to sign.__
 
 After you signed, the PR is checked again automatically after a minute. If there's still an issue, please reply here to let us know.
 
 ---
 
-If you've already signed our CLA, it's possible your git author information doesn't match your CLA signature (both your name and email have to match), for more information, [check the status of your CLA check](http://contribute.jquery.org/CLA/status/?owner={{owner}}&repo={{repo}}&sha={{head}}).
+If you've already signed our CLA, it's possible your git author information doesn't match your CLA signature (both your name and email have to match), for more information, [check the status of your CLA check](https://js.foundation/CLA/status/?owner={{owner}}&repo={{repo}}&sha={{head}}).

--- a/lib/pr.js
+++ b/lib/pr.js
@@ -222,7 +222,7 @@ Audit.prototype.finishAudit = function( values ) {
 		status = {
 			sha: this.options.head,
 			state: result.state,
-			url: "http://contribute.jquery.org/CLA/status/?" + querystring.stringify( {
+			url: "https://js.foundation/CLA/status/?" + querystring.stringify( {
 				owner: this.options.owner,
 				repo: this.options.repo,
 				sha: this.options.head

--- a/lib/repo/github.js
+++ b/lib/repo/github.js
@@ -54,7 +54,7 @@ Repo.prototype.getPrCommitData = function( pr ) {
 Repo.prototype.setStatus = function( options ) {
 	var data = {
 		state: options.state,
-		context: "jQuery Foundation CLA"
+		context: "JS Foundation CLA"
 	};
 
 	if ( options.url ) {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "jquery-license",
   "version": "1.1.6",
-  "description": "License verification for jQuery Foundation projects",
+  "description": "License verification for JS Foundation projects",
   "repository": {
     "type": "git",
     "url": "git://github.com/jquery/jquery-license.git"
   },
   "author": {
-    "name": "jQuery Foundation and other contributors"
+    "name": "JS Foundation and other contributors"
   },
   "licenses": [
     {


### PR DESCRIPTION
First pass at renaming jQuery Foundation to JS Foundation of #72.
I haven't changed references to `jquerybot` yet since there isn't a new name to replace it with yet.
